### PR TITLE
gh-15: Partially addresses the issue of layer readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dependencies": {
         "infusion": "3.0.0-dev.20181204T213346Z.2ca90f6e6",
         "kettle": "1.9.0",
-        "aconite": "0.9.1",
+        "aconite": "0.10.0",
         "flocking": "2.0.0-dev.20190101T211732Z.efbf6e2",
         "infusion-electron": "0.6.0-dev.20190114T195841Z.9a0b8fe.gh-5",
         "normalize.css": "8.0.1"

--- a/src/renderer-process/js/compositor.js
+++ b/src/renderer-process/js/compositor.js
@@ -13,14 +13,11 @@ fluid.defaults("bubbles.compositor", {
     fps: 60,
 
     model: {
-        // TODO: This needs to be "numReadyLayers",
-        // Created by incrementing a model field when videos
-        // are ready.
-        numLayers: 0
+        numReadyLayers: 0
     },
 
     uniformModelMap: {
-        numLayers: "numLayers"
+        numReadyLayers: "numReadyLayers"
     },
 
     listeners: {

--- a/src/renderer-process/js/dynamic-component-manager.js
+++ b/src/renderer-process/js/dynamic-component-manager.js
@@ -7,6 +7,8 @@ https://github.com/colinbdclark/bubbles/raw/master/LICENSE
 
 "use strict";
 
+var bubbles = fluid.registerNamespace("bubbles");
+
 /**
  * Responsible for firing events that can be used to create
  * or destroy components based on a modelized representation

--- a/src/renderer-process/js/gl-renderer.js
+++ b/src/renderer-process/js/gl-renderer.js
@@ -16,7 +16,7 @@ fluid.defaults("bubbles.glRenderer", {
     },
 
     uniforms: {
-        numLayers: {
+        numReadyLayers: {
             type: "1i",
             values: 0
         },

--- a/src/renderer-process/js/layer-stack.js
+++ b/src/renderer-process/js/layer-stack.js
@@ -7,6 +7,8 @@ https://github.com/colinbdclark/bubbles/raw/master/LICENSE
 
 "use strict";
 
+var bubbles = fluid.registerNamespace("bubbles");
+
 fluid.defaults("bubbles.layerStack", {
     gradeNames: "fluid.viewComponent",
 
@@ -41,8 +43,7 @@ fluid.defaults("bubbles.layerStack", {
                 // Is there a real transform I can use here?
                 type: "fluid.transforms.free",
                 func: "bubbles.layerStack.countLayers",
-                args: "{that}.model.layers",
-
+                args: "{that}.model.layers"
             }
         }
     ],
@@ -143,7 +144,7 @@ bubbles.layerStack.handleLayerChange = function (that, change) {
     // TODO: Currently, there is no way to remove a layer
     // after it has been added.
     if (change.oldValue > change.value) {
-        that.applier.change(numLayers, change.oldValue);
+        that.applier.change("numLayers", change.oldValue);
     } else {
         that.events.onAddNewLayer.fire(change.value);
     }
@@ -168,7 +169,7 @@ bubbles.layerStack.createComponentEntry = function (that) {
         layerIdx: that.model.numLayers,
         url: undefined
     });
-}
+};
 
 bubbles.layerStack.countLayers = function (layers) {
     return layers ? Object.keys(layers).length : 0;

--- a/src/renderer-process/js/layer-stack.js
+++ b/src/renderer-process/js/layer-stack.js
@@ -22,6 +22,8 @@ fluid.defaults("bubbles.layerStack", {
              * they transition to/from being ready to play.
              */
             record: {
+                // TODO: Could this be done with a model
+                // transformation of some kinds?
                 modelListeners: {
                     canPlayThrough: {
                         namespace: "incrementLayerStackReady",

--- a/src/renderer-process/js/video-layer-view.js
+++ b/src/renderer-process/js/video-layer-view.js
@@ -7,8 +7,6 @@ https://github.com/colinbdclark/bubbles/raw/master/LICENSE
 
 "use strict";
 
-var bubbles = fluid.registerNamespace("bubbles");
-
 fluid.defaults("bubbles.videoLayerView", {
     gradeNames: "fluid.viewComponent",
 

--- a/src/renderer-process/js/video-layer.js
+++ b/src/renderer-process/js/video-layer.js
@@ -7,6 +7,8 @@ https://github.com/colinbdclark/bubbles/raw/master/LICENSE
 
 "use strict";
 
+var bubbles = fluid.registerNamespace("bubbles");
+
 fluid.defaults("bubbles.videoLayer", {
     gradeNames: "aconite.compositableVideo",
 

--- a/src/renderer-process/shaders/bubbles.frag
+++ b/src/renderer-process/shaders/bubbles.frag
@@ -2,18 +2,18 @@ precision highp float;
 
 const int MAX_LAYERS = 16;
 
-uniform int numLayers;
+uniform int numReadyLayers;
 uniform sampler2D layerSamplers[MAX_LAYERS];
 uniform vec2 textureSize;
 
 void main(void) {
     vec2 coords = vec2(gl_FragCoord.x / textureSize.x, gl_FragCoord.y / textureSize.y);
 
-    float scale = float(numLayers);
+    float scale = float(numReadyLayers);
     vec4 layerSum = vec4(0.0, 0.0, 0.0, 1.0);
 
     for (int i = 0; i < MAX_LAYERS; i++) {
-        if (i > numLayers) {
+        if (i >= numReadyLayers) {
             break;
         }
         vec4 frag = texture2D(layerSamplers[i], coords);

--- a/src/renderer-process/shaders/bubbles.frag
+++ b/src/renderer-process/shaders/bubbles.frag
@@ -12,6 +12,10 @@ void main(void) {
     float scale = float(numReadyLayers);
     vec4 layerSum = vec4(0.0, 0.0, 0.0, 1.0);
 
+    // TODO: The "there is no texture bound" warning will always happen,
+    // even if the number of iterations is set to be lower (e.g. 1),
+    // or if we only read from layerSamplers[0].
+    // But it will go away if we don't touch layerSamplers at all.
     for (int i = 0; i < MAX_LAYERS; i++) {
         if (i >= numReadyLayers) {
             break;


### PR DESCRIPTION
This PR ensures that the shader is properly informed of the number of layers that are actually ready to be composited—i.e. whose videos have loaded and can play through to the end.

It does not, however, address the fact that samplers are declared for textures that may not yet have anything bound to them, and which won't actually be read from until their layer is ready. However, GL will still log warnings for these unbound textures.

In order to fix this, I think it's likely that we'll need to also continually update the texture numbers in the <code>layerSamplers</code> array as new layers become ready. For now, I'll defer this until Aconite's uniform-handling code is cleaned up.