### PR TITLE
gh-46: Updates to latest electron and kettle dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "readmeFilename": "README.md",
     "main": "main.js",
     "devDependencies": {
-        "electron": "4.2.0",
-        "electron-packager": "13.1.1",
+        "electron": "5.0.6",
+        "electron-packager": "14.0.1",
         "electron-icon-maker": "0.0.4",
         "grunt": "1.0.4",
         "gpii-grunt-lint-all": "1.0.5",
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "infusion": "3.0.0-dev.20190328T144119Z.ec44dbfab",
-        "kettle": "1.10.1",
+        "kettle": "1.11.0",
         "aconite": "0.11.1",
         "flocking": "2.0.1",
         "infusion-electron": "0.6.0",

--- a/src/renderer-process/css/modulation-matrix.css
+++ b/src/renderer-process/css/modulation-matrix.css
@@ -1,8 +1,8 @@
 .bubbles-modulation-matrix {
     display: grid;
     grid-template-columns: 25% 25% 25% 25%;
-    grid-template-rows: 50% 50%;
-    width: 50%;
+    grid-template-rows: auto;
+    padding-left: 1em;
 }
 
 .bubbles-modulator {


### PR DESCRIPTION
Fixes grid issue introduced with newer version of Chromium used in Electron 5.x.